### PR TITLE
Update to 1.0.27, add fedc annotations, update to GNOME 42 runtime

### DIFF
--- a/org.gnome.Genius.appdata.xml
+++ b/org.gnome.Genius.appdata.xml
@@ -48,6 +48,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.0.27" date="2021-10-27"/>
     <release date="2021-02-19" version="1.0.26"/>
     <release date="2020-03-05" version="1.0.25"/>
     <release date="2018-05-15" version="1.0.24"/>

--- a/org.gnome.Genius.appdata.xml
+++ b/org.gnome.Genius.appdata.xml
@@ -53,6 +53,6 @@
     <release date="2018-05-15" version="1.0.24"/>
     <release date="2017-05-10" version="1.0.23"/>
   </releases>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
   <update_contact>nick_at_nedrichards.com</update_contact>
 </component>

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -14,10 +14,15 @@
         "--persist=.genius"
     ],
     "cleanup": [
-        "/include", "/lib/pkgconfig",
-        "/share/pkgconfig", "/share/aclocal",
-        "/man", "/share/man", "/share/gtk-doc",
-        "*.la", "*.a"
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "*.la",
+        "*.a"
     ],
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
@@ -78,13 +83,13 @@
             ]
         },
         {
-            "name" : "vte",
-            "buildsystem" : "meson",
+            "name": "vte",
+            "buildsystem": "meson",
             "config-opts": [
                 "-Ddocs=false",
                 "-Dvapi=false"
             ],
-            "sources" : [
+            "sources": [
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/vte/0.62/vte-0.62.3.tar.xz",
@@ -96,9 +101,9 @@
             "name": "genius",
             "sources": [
                 {
-                "type": "archive",
-                "url": "http://ftp.5z.com/pub/genius/genius-1.0.26.tar.xz",
-                "sha256": "d115ed3f8278580308374dd8325de415b528edc1492c5e775eae2a3b65ad6d16"
+                    "type": "archive",
+                    "url": "http://ftp.5z.com/pub/genius/genius-1.0.26.tar.xz",
+                    "sha256": "d115ed3f8278580308374dd8325de415b528edc1492c5e775eae2a3b65ad6d16"
                 },
                 {
                     "type": "file",

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -44,6 +44,12 @@
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 234776,
+                        "stable-only": true,
+                        "url-template": "https://ftp.gnu.org/gnu/ncurses/ncurses-$version.tar.gz"
+                    },
                     "type": "archive",
                     "url": "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz",
                     "sha256": "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
@@ -54,6 +60,11 @@
             "name": "mpfr",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 2019,
+                        "url-template": "https://www.mpfr.org/mpfr-current/mpfr-$version.tar.xz"
+                    },
                     "type": "archive",
                     "url": "https://www.mpfr.org/mpfr-current/mpfr-4.1.0.tar.xz",
                     "sha256": "0c98a3f1732ff6ca4ea690552079da9c597872d30e96ec28414ee23c95558a7f"
@@ -65,6 +76,10 @@
             "buildsystem": "meson",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "amtk"
+                    },
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/amtk/5.3/amtk-5.3.1.tar.xz",
                     "sha256": "d5aa236c5d71dc41aa4674f345560a67a27f21c0efc97c9b3da09cb582b4638b"
@@ -76,6 +91,14 @@
             "buildsystem": "meson",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gtksourceview",
+                        "//": "gtksourceview5 is the GTK 4 version",
+                        "versions": {
+                            "<": "5.0.0"
+                        }
+                    },
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.0.tar.xz",
                     "sha256": "00a19121500cedf1bae97f35af865d839841fd785d9facf188498e13975b4e1a"
@@ -91,6 +114,10 @@
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "vte"
+                    },
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/vte/0.62/vte-0.62.3.tar.xz",
                     "sha256": "f5770285a52cc23a3c0428a43d492b7c0ba458ce7b8a73768a7d4f1e8a7db3b4"
@@ -101,6 +128,11 @@
             "name": "genius",
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 9839,
+                        "url-template": "http://ftp.5z.com/pub/genius/genius-$version.tar.xz"
+                    },
                     "type": "archive",
                     "url": "http://ftp.5z.com/pub/genius/genius-1.0.26.tar.xz",
                     "sha256": "d115ed3f8278580308374dd8325de415b528edc1492c5e775eae2a3b65ad6d16"

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Genius",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-genius",
     "rename-desktop-file": "gnome-genius.desktop",

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -11,7 +11,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--own-name=org.gnome.genius",
-        "--persist=.gnome2"
+        "--persist=.genius"
     ],
     "cleanup": [
         "/include", "/lib/pkgconfig",

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -51,8 +51,8 @@
                         "url-template": "https://ftp.gnu.org/gnu/ncurses/ncurses-$version.tar.gz"
                     },
                     "type": "archive",
-                    "url": "https://ftp.gnu.org/gnu/ncurses/ncurses-6.2.tar.gz",
-                    "sha256": "30306e0c76e0f9f1f0de987cf1c82a5c21e1ce6568b9227f7da5b71cbea86c9d"
+                    "url": "https://ftp.gnu.org/gnu/ncurses/ncurses-6.3.tar.gz",
+                    "sha256": "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059"
                 }
             ]
         },
@@ -81,8 +81,8 @@
                         "name": "amtk"
                     },
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/amtk/5.3/amtk-5.3.1.tar.xz",
-                    "sha256": "d5aa236c5d71dc41aa4674f345560a67a27f21c0efc97c9b3da09cb582b4638b"
+                    "url": "https://download.gnome.org/sources/amtk/5.4/amtk-5.4.1.tar.xz",
+                    "sha256": "7ebabc429b0eebb2b32360c9bfdbe368e489b35c3cdc086a856cfc9b3a466a72"
                 }
             ]
         },
@@ -100,8 +100,8 @@
                         }
                     },
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.0.tar.xz",
-                    "sha256": "00a19121500cedf1bae97f35af865d839841fd785d9facf188498e13975b4e1a"
+                    "url": "https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.3.tar.xz",
+                    "sha256": "c30019506320ca2474d834cced1e2217ea533e00eb2a3f4eb7879007940ec682"
                 }
             ]
         },
@@ -119,8 +119,8 @@
                         "name": "vte"
                     },
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/vte/0.62/vte-0.62.3.tar.xz",
-                    "sha256": "f5770285a52cc23a3c0428a43d492b7c0ba458ce7b8a73768a7d4f1e8a7db3b4"
+                    "url": "https://download.gnome.org/sources/vte/0.68/vte-0.68.0.tar.xz",
+                    "sha256": "13e7d4789ca216a33780030d246c9b13ddbfd04094c6316eea7ff92284dd1749"
                 }
             ]
         },
@@ -134,8 +134,8 @@
                         "url-template": "http://ftp.5z.com/pub/genius/genius-$version.tar.xz"
                     },
                     "type": "archive",
-                    "url": "http://ftp.5z.com/pub/genius/genius-1.0.26.tar.xz",
-                    "sha256": "d115ed3f8278580308374dd8325de415b528edc1492c5e775eae2a3b65ad6d16"
+                    "url": "http://ftp.5z.com/pub/genius/genius-1.0.27.tar.xz",
+                    "sha256": "39098d0054ccc60b4b0ff6ca37276c72eea73806082d4c2e9738a29b7c78b20a"
                 },
                 {
                     "type": "file",

--- a/org.gnome.Genius.json
+++ b/org.gnome.Genius.json
@@ -11,7 +11,8 @@
         "--socket=x11",
         "--socket=wayland",
         "--own-name=org.gnome.genius",
-        "--persist=.genius"
+        "--persist=.genius",
+        "--persist=.gnome2"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
- Config storage fix for #2 from #6 
- Canonicalise manifest & appdata formatting
- Add flatpak-external-data-checker annotations
- Update to 1.0.27
- Update to GNOME 42 runtime

Fixes #2.